### PR TITLE
fix: restart services and allow overwriting configs

### DIFF
--- a/fluent-bit.conf
+++ b/fluent-bit.conf
@@ -27,7 +27,7 @@
 # uncomment this next line
 #    Record appgroup ha-proxy
     Record host ${HOSTNAME}
-    Record datacenter aws
+    Record datacenter AWS
     Remove_key _MACHINE_ID
 
 [INPUT]

--- a/telegraf.conf
+++ b/telegraf.conf
@@ -1,6 +1,6 @@
 [global_tags]
   # update datacenter names to match Fluent Bit config
-  datacenter = "aws"
+  datacenter = "AWS"
 [agent]
   interval = "10s"
   round_interval = true


### PR DESCRIPTION
Allows rewriting configs, sets the default datacenter to `AWS` instead of `aws` for consistency across OSes, and forces services to restart when the configs are written.