### PR TITLE
feat: increase data collected

### DIFF
--- a/osquery.conf
+++ b/osquery.conf
@@ -38,6 +38,21 @@
       "query": "SELECT * FROM os_version;", 
       "snapshot": true,
       "interval": 60
+    },
+    "process_hash_snapshot": {
+      "query": "SELECT DISTINCT h.sha256, p.name, u.username FROM processes AS p INNER JOIN hash as h ON h.path = p.path INNER JOIN users AS u ON u.uid = p.uid ORDER BY start_time DESC;",
+      "snapshot": true,
+      "interval": 60
+    },
+    "process_netports_snapshot": {
+      "query": "SELECT lp.pid, p.name, lp.port, lp.address FROM listening_ports AS lp INNER JOIN processes AS p ON lp.pid = p.pid WHERE lp.port != 0 AND lp.address != \"127.0.0.1\" ORDER BY p.start_time DESC;",
+      "snapshot": true,
+      "interval": 60
+    },
+    "process_netconns_snapshot": {
+      "query": "SELECT (CASE family WHEN 2 THEN 'IP4' WHEN 10 THEN 'IP6' ELSE family END) AS family, (CASE protocol WHEN 6 THEN 'TCP' WHEN 17 THEN 'UDP' ELSE protocol END) AS protocol, local_address, local_port, remote_address, remote_port FROM process_open_sockets WHERE family IN (2, 10) AND protocol IN (6, 17) AND local_address != \"0.0.0.0\" AND remote_address != \"0.0.0.0\" AND remote_port != 0;",
+      "snapshot": true,
+      "interval": 60
     }
   },
   "decorators": {


### PR DESCRIPTION
tested on Win10. Adds scrapes of process hashes, network connections, and listening ports, parity with a Linux PR at https://github.com/observeinc/linux-host-configuration-scripts/pull/30
