### PR TITLE
feat: add win_wmi input to telegraf for process commands

### DIFF
--- a/telegraf.conf
+++ b/telegraf.conf
@@ -62,6 +62,17 @@ UseWildcardsExpansion = true
     #IncludeTotal=false #Set to true to include _Total instance when querying for all (*).
 [[inputs.win_services]]
   # no configurations
+[[inputs.win_wmi]]
+  name_prefix = "win_wmi_"
+  [[inputs.win_wmi.query]]
+    namespace = "root\\cimv2"
+    class_name = "Win32_Process"
+    properties = [
+      "Name",
+      "CommandLine",
+      "ProcessId",
+    ]
+    tag_properties = ["Name","CommandLine"]
 # Uncomment below metatags if using AWS EC2
 #####[[processors.aws_ec2]]
 #####  imds_tags = [ "accountId", "instanceId"]


### PR DESCRIPTION
Collect command-line for Windows processes through wmi directly.