### PR TITLE
Update fluent-bit.conf to allow for larger log lines to be ingested

### DIFF
--- a/fluent-bit.conf
+++ b/fluent-bit.conf
@@ -39,6 +39,9 @@
     path C:\Program Files\osquery\log\osqueryd.results.log
     Read_from_Head False
     db      osquery-results.db
+    Mem_Buf_Limit       30MB
+    Buffer_Chunk_Size   100k
+    Buffer_Max_Size     5MB
 [INPUT]
     name tail
     tag  tail_osquery_snapshots
@@ -46,6 +49,9 @@
     path C:\Program Files\osquery\log\osqueryd.snapshots.log
     Read_from_Head False
     db      osquery-snapshots.db
+    Mem_Buf_Limit       30MB
+    Buffer_Chunk_Size   100k
+    Buffer_Max_Size     5MB
 [OUTPUT]
     name        http
     match       *


### PR DESCRIPTION
One of our customers had an issue with Windows snapshot queries that would generate very long lines.