### PR TITLE
fix: bump fluentbit version to latest and expose params for agent versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@
     * -appgroup = value to use for appgroup record in fluent-bit.conf file  - OPTIONAL - defaults to null
     * -local = TRUE/FLASE on whether or not use to local config files instead of the default config files - OPTIONAL - default to FALSE
     * -force = TRUE/FALSE on whether or not overwrite agent config files without confirmation (true will overwrite) - OPTION - default to FALSE
-
-
-
+    * -osquery_version = value for which osquery version to install (defaults to "5.8.2")
+    * -telegraf_version = value for which telegraf version to install (defaults to "1.26.0")
+    * -fluentbit_version = value for which fluent-bit version to install (defaults to "2.1.10")
 
 1. Run following script
 ```

--- a/agents.ps1
+++ b/agents.ps1
@@ -9,7 +9,10 @@ param (
     $appgroup=$null,
     $local=$false,
     $force=$false,
-    $branch="main"
+    $branch="main",
+    $osquery_version="5.8.2",
+    $telegraf_version="1.26.0",
+    $fluentbit_version="2.1.10"
     )
 
     # sanitize host name
@@ -19,9 +22,6 @@ param (
 
     $observe_host_name = $observe_host_name -Replace "https://", "" -Replace ".com/", ".com" -Replace "http://", ""
 
-    $osquery_version = "5.8.2"
-    $telegraf_version = "1.26.0"
-    $fluentbit_version = "2.0.9"
     
     $temp_dir  = "C:\temp\observe"
     $osquery_msiexec_args = "/I ${temp_dir}\osquery-$osquery_version.msi TARGETDIR=```"${Env:Programfiles}\osquery```" /qn"
@@ -59,7 +59,7 @@ param (
             AgentName = "fluentbit"
             TestDestination = "${Env:Programfiles}\fluent-bit"
             Version = $fluentbit_version
-            InstallerUrl ="https://fluentbit.io/releases/2.0/fluent-bit-${fluentbit_version}-win64.exe"
+            InstallerUrl ="https://fluentbit.io/releases/$($fluentbit_version.Split(".")[0..1] -join "." )/fluent-bit-${fluentbit_version}-win64.exe"
             DownloadDest = "$temp_dir\fluent-bit-${fluentbit_version}.exe"
             InstallationExpression = "Start-Process $temp_dir\fluent-bit-${fluentbit_version}.exe -ArgumentList `"/S /D=```"$Env:Programfiles\fluent-bit```"`" -Wait -ErrorAction Stop"
             ConfigTemplate = "https://raw.githubusercontent.com/observeinc/windows-host-configuration-scripts/$branch/fluent-bit.conf"


### PR DESCRIPTION
## What does this PR do?

1. Bumps the version of fluentbit that the windows agent install script uses to `2.1.10`
2. Makes the fluentbit, osquery, and telegraf vresions that the agent install script uses configurable parameters so that customers who need specific versions can be unblocked in the future
    * -osquery_version = value for which osquery version to install (defaults to "5.8.2")
    * -telegraf_version = value for which telegraf version to install (defaults to "1.26.0")
    * -fluentbit_version = value for which fluent-bit version to install (defaults to "2.1.10")
3. Fixes the fluentbit installation executable download path to be defined by the version (was hard-locked to `2.0` flavors)

## Testing

Installation succeeded on windows server 2016, 2019, and 2022 in this [test run](https://github.com/observeinc/linux-host-configuration-scripts/actions/runs/6420683784). 