### PR TITLE
fix: restart agents on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@
     * -osquery_version = value for which osquery version to install (defaults to "5.8.2")
     * -telegraf_version = value for which telegraf version to install (defaults to "1.26.0")
     * -fluentbit_version = value for which fluent-bit version to install (defaults to "2.1.10")
+    * -service_restart_delay = delay in milliseconds for restarting failed service (defaults to 5000)
+    * -service_max_restarts = max number of attempts to restart failed services (defaults to 5)
 
 1. Run following script
 ```


### PR DESCRIPTION
Sets up all agents we configure to restart on failures.  This isn't the default behavior of any of them.  Setting the delay between restarts at 5s and a max retry count of 5 failures initially.  We can change this behavior by passing in the corresponding flags.  