### PR TITLE
fix: do not kill the running process when looking for duplicate instances

### DIFF
--- a/fluent-bit-watchdog/intstall.ps1
+++ b/fluent-bit-watchdog/intstall.ps1
@@ -93,6 +93,8 @@ $principal = New-ScheduledTaskPrincipal -UserId "NT AUTHORITY\SYSTEM" -LogonType
 
 if (Get-ScheduledTask -TaskName $taskName -TaskPath $taskPath -ErrorAction SilentlyContinue ) {
     Set-ScheduledTask -TaskName $taskName -TaskPath $taskPath -Action $action -Trigger $triggers -Settings $settings -Principal $principal
+    # start task if the task already exists
+    Start-ScheduledTask -TaskPath $taskPath -TaskName $taskName  
 } else {
     Register-ScheduledTask -TaskName $taskName -TaskPath $taskPath -Action $action -Trigger $triggers -Settings $settings -Principal $principal
 }

--- a/fluent-bit-watchdog/watchdog.ps1
+++ b/fluent-bit-watchdog/watchdog.ps1
@@ -9,8 +9,11 @@
 $existingInstances =  Get-WmiObject Win32_Process -Filter "Name='powershell.exe' AND CommandLine LIKE '%watchdog.ps1%'" | Select-Object -ExpandProperty ProcessID
 # Terminate any existing instances of the script
 foreach ($instance in $existingInstances) {
-    Write-EventLog -LogName "Application" -Source "Application" -EventID 1003 -EntryType Info -Message "Found running instance ${instance}, killing it."
-    Stop-Process -Id $instance -Force
+    # Ignore my current instance
+    if($instance -ne $PID){
+        Write-EventLog -LogName "Application" -Source "Application" -EventID 1003 -EntryType Info -Message "Found another running instance (PID:${instance}), killing it."
+        Stop-Process -Id $instance -Force
+    }
  } 
 
 $promUri = "http://localhost:2021/api/v1/metrics/prometheus"


### PR DESCRIPTION
Previously we were killing the current process itself by blindly removing all PIDs that match.  This keeps the current process running.