### PR TITLE
fix: restart fluent-bit in watchdog if not running

### DIFF
--- a/fluent-bit-watchdog/README.md
+++ b/fluent-bit-watchdog/README.md
@@ -4,11 +4,13 @@ To install the fluent-bit watchdog, run the command below. The script will do th
  - update telegraf config to ship those metrics to Observe
  - creates a scheduled task to monitor fluent-bit
     - restart fluent-bit if `fluentbit_output_proc_records_total` stagnates for 3 minutes
+    - starts fluent-bit if it is not running
+    - starts fluent-bit if the prometheus endpoint is not available
 
 
 1. To install, simply run:
 ```powershell
-Invoke-Expression (Invoke-WebRequest -Uri "https://raw.githubusercontent.com/observeinc/windows-host-configuration-scripts/main/fluent-bit-watchdog/intstall.ps1").Content
+Invoke-Expression (Invoke-WebRequest -Uri "https://raw.githubusercontent.com/observeinc/windows-host-configuration-scripts/main/fluent-bit-watchdog/intstall.ps1" -UseBasicParsing).Content
 ```
 
 NOTE: This assumes you have installed the Observe agents located in the root of this repository.


### PR DESCRIPTION
This PR restarts fluent-bit if the service isn't running or if the prometheus endpoint becomes unavailable.  The script was originally written with the understanding that the service keeps running when it crashes but it looks like that is not the case.  README also updated to reflect the change in behavior.  Backoff logic was ripped out since that functionality was there to back off if fluent-bit wasn't running but now that we restart we don't want to backoff. Tested on a Windows VM.